### PR TITLE
Added run_id as a keyword and support for out of the box functions.

### DIFF
--- a/grammars/cloudslang.cson
+++ b/grammars/cloudslang.cson
@@ -47,7 +47,7 @@
   #   keyword: |
   #   keyword: >
   {
-    'begin': '^(\\s*)(?:(-)|(?:(-(\\s*))?((namespace|imports|flow|name|inputs|workflow|do|publish|navigate|outputs|results|operation|decision|python_action|dependencies|java_action|gav|parallel_loop|loop|for|break|class_name|method_name|script|on_failure|properties|extensions)\\s*(:))))\\s*(\\||>)'
+    'begin': '^(\\s*)(?:(-)|(?:(-(\\s*))?((namespace|imports|flow|name|inputs|workflow|do|publish|navigate|outputs|results|operation|decision|python_action|dependencies|java_action|gav|parallel_loop|loop|for|break|class_name|method_name|script|on_failure|properties|extensions|run_id)\\s*(:))))\\s*(\\||>)'
     'beginCaptures':
       '5':
         'name': 'keyword'
@@ -57,7 +57,7 @@
   # other than multi-line string syntax - e.g.:
   #   keyword: str
   {
-    'match': '(\\s*)(-\\s*)?((namespace|imports|flow|name|inputs|workflow|do|publish|navigate|outputs|results|operation|decision|python_action|dependencies|java_action|gav|parallel_loop|loop|for|break|class_name|method_name|script|on_failure|properties|extensions)(:))([^#\\n]*)(#.*)?\\n'
+    'match': '(\\s*)(-\\s*)?((namespace|imports|flow|name|inputs|workflow|do|publish|navigate|outputs|results|operation|decision|python_action|dependencies|java_action|gav|parallel_loop|loop|for|break|class_name|method_name|script|on_failure|properties|extensions|run_id)(:))([^#\\n]*)(#.*)?\\n'
     'captures':
       '2':
         'name': 'string.unquoted.block.yaml'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-cloudslang",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "CloudSlang extension",
   "keywords": [
     "automation",

--- a/snippets/language-cloudslang.cson
+++ b/snippets/language-cloudslang.cson
@@ -307,60 +307,60 @@
   'Run id':
     'prefix': 'run_id'
     'body': """
-        - ${1:run_id}:
+        ${1:run_id}:
     """
   'cs_append':
       'prefix': 'cs_append'
       'body': """
-          - cs_append(${1:input_1},to_append)
+          cs_append(${1:input_1},to_append)
       """
   'cs_extract_number':
       'prefix': 'cs_extract_number'
       'body': """
-          - cs_extract_number(${1:input_1},n_th)
+          cs_extract_number(${1:input_1},n_th)
       """
   'cs_substring':
       'prefix': 'cs_substring'
       'body': """
-          - cs_substring(${1:input_1},start_position,optional_end_position)
+          cs_substring(${1:input_1},start_position,optional_end_position)
       """
   'cs_to_lower':
       'prefix': 'cs_to_lower'
       'body': """
-          - cs_to_lower(${1:input_1})
+          cs_to_lower(${1:input_1})
       """
   'cs_to_upper':
       'prefix': 'cs_to_upper'
       'body': """
-          - cs_to_upper(${1:input_1})
+          cs_to_upper(${1:input_1})
       """
   'cs_prepend':
       'prefix': 'cs_prepend'
       'body': """
-          - cs_prepend(${1:input_1},to_prepend)
+          cs_prepend(${1:input_1},to_prepend)
       """
   'cs_regex':
       'prefix': 'cs_regex'
       'body': """
-          - cs_regex(${1:input_1},regex,optional_split_lines)
+          cs_regex(${1:input_1},regex,optional_split_lines)
       """
   'cs_replace':
       'prefix': 'cs_replace'
       'body': """
-          - cs_replace(${1:input_1},old_value, new_value, count)
+          cs_replace(${1:input_1},old_value, new_value, count)
       """
   'cs_round':
       'prefix': 'cs_round'
       'body': """
-          - cs_round(${1:input_1})
+          cs_round(${1:input_1})
       """
   'cs_xpath_query':
       'prefix': 'cs_xpath_query'
       'body': """
-          - cs_append(${1:input_1},xpath)
+          cs_xpath_query(${1:input_1},xpath)
       """
   'cs_json_query':
       'prefix': 'cs_json_query'
       'body': """
-          - cs_append(${1:input_1},json_path)
+          cs_json_query(${1:input_1},json_path)
       """

--- a/snippets/language-cloudslang.cson
+++ b/snippets/language-cloudslang.cson
@@ -303,3 +303,64 @@
               value: ${2:property_value}
               sensitive: ${3:sensitive_value}
     """
+
+  'Run id':
+    'prefix': 'run_id'
+    'body': """
+        - ${1:run_id}:
+    """
+  'cs_append':
+      'prefix': 'cs_append'
+      'body': """
+          - cs_append(${1:input_1},to_append)
+      """
+  'cs_extract_number':
+      'prefix': 'cs_extract_number'
+      'body': """
+          - cs_extract_number(${1:input_1},n_th)
+      """
+  'cs_substring':
+      'prefix': 'cs_substring'
+      'body': """
+          - cs_substring(${1:input_1},start_position,optional_end_position)
+      """
+  'cs_to_lower':
+      'prefix': 'cs_to_lower'
+      'body': """
+          - cs_to_lower(${1:input_1})
+      """
+  'cs_to_upper':
+      'prefix': 'cs_to_upper'
+      'body': """
+          - cs_to_upper(${1:input_1})
+      """
+  'cs_prepend':
+      'prefix': 'cs_prepend'
+      'body': """
+          - cs_prepend(${1:input_1},to_prepend)
+      """
+  'cs_regex':
+      'prefix': 'cs_regex'
+      'body': """
+          - cs_regex(${1:input_1},regex,optional_split_lines)
+      """
+  'cs_replace':
+      'prefix': 'cs_replace'
+      'body': """
+          - cs_replace(${1:input_1},old_value, new_value, count)
+      """
+  'cs_round':
+      'prefix': 'cs_round'
+      'body': """
+          - cs_round(${1:input_1})
+      """
+  'cs_xpath_query':
+      'prefix': 'cs_xpath_query'
+      'body': """
+          - cs_append(${1:input_1},xpath)
+      """
+  'cs_json_query':
+      'prefix': 'cs_json_query'
+      'body': """
+          - cs_append(${1:input_1},json_path)
+      """


### PR DESCRIPTION
Now the plugin recognizes "run_id" as a keyword and also helps in auto completion of the cslang out of the box functions which are listed below.

  'cs_append'
     
  'cs_extract_number'
   
  'cs_substring'
      
  'cs_to_lower'
     
  'cs_to_upper'
      
  'cs_prepend'
    
  'cs_regex'
     
  'cs_replace'
     
  'cs_round'
     
  'cs_xpath_query'
     
  'cs_json_query'
      
